### PR TITLE
Remove string allocations from is_next_insensitive

### DIFF
--- a/parser/src/lexer/mod.rs
+++ b/parser/src/lexer/mod.rs
@@ -36,12 +36,13 @@ impl<'c> Lexer<'c> {
   }
 
   fn is_next_insensitive(&mut self, peek: char) -> bool {
-    let result = self.chars.peek().map(|c| c.to_lowercase().to_string())
-      == Some(peek.to_lowercase().to_string());
-    if result {
+    if self.chars.peek()
+      .map(|c| c.to_lowercase())
+      .map(|s| peek.to_lowercase().eq(s))
+      .unwrap_or(false) {
       self.advance();
-    }
-    result
+      true
+    } else { false }
   }
 
   fn read_eol(&mut self) -> String {


### PR DESCRIPTION
The function `is_next_insensitive` allocated two strings by utilizing the `ToString` trait for `std::option::Option<std::char::ToLowercase>`.

I had some concerns regarding the actual validity of this check, since an `std::option::Option<std::char::ToLowercase>` is directly converted to a `String` without unwrapping first.

I rewrote the function to `map` the character to its lowercase representation and `map` the result to a boolean indicating whether the current character and the peeked character are the same using `Iterator.eq`.

In the process I was able to remove two string allocations and only work with guaranteed unwrapped values.

All tests are passing after this change.